### PR TITLE
error handling

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -198,3 +198,8 @@ footer {
   width: 60%;
   border-radius: 10px;
 }
+
+// エラーメッセージ
+.error_message{
+  color: red;
+}

--- a/app/controllers/buildings_controller.rb
+++ b/app/controllers/buildings_controller.rb
@@ -1,6 +1,6 @@
 class BuildingsController < ApplicationController
   before_action :set_up_building, only: [:edit, :update, :destroy, :search]
-  before_action :set_up_form, only: [:new, :edit]
+  before_action :set_up_form, only: [:new, :create, :edit]
   # 一覧画面に対するアクション
   def index
     @buildings = Building.where(user_id: current_user.id).order(:id)
@@ -14,7 +14,12 @@ class BuildingsController < ApplicationController
 
   # 新規建物登録アクション
   def create
-    @building = Building.create(building_params)
+    @building = Building.new(building_params)
+    if @building.save
+      redirect_to buildings_path
+    else
+      render :new
+    end
   end
 
   # 建物情報編集アクション

--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -1,14 +1,13 @@
 class Building < ApplicationRecord
   validates :name, presence: true
   validates :address, presence: true
-  validates :entirety_usege_id, presence: true
-  validates :entirety_floor, presence: true
-  validates :basement_floor, presence: true
-  validates :total_area, presence: true
-  validates :total_capacity, presence: true
+  validates :entirety_usege_id, presence: { message: "を選択してください" }
+  validates :entirety_floor, presence: { message: "を選択してください" }
+  validates :basement_floor, presence: { message: "を選択してください" }
+  validates :total_area, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :total_capacity, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :fire_use, presence: true
-
-  belongs_to :entirety_usege
+  belongs_to :entirety_usege, optional: :true
   has_many :information_by_floors, dependent: :destroy
   accepts_nested_attributes_for :information_by_floors, allow_destroy: true
   has_many :information_by_basement_floors, dependent: :destroy

--- a/app/models/information_by_basement_floor.rb
+++ b/app/models/information_by_basement_floor.rb
@@ -1,5 +1,9 @@
 class InformationByBasementFloor < ApplicationRecord
-  validates :floor_number, presence: true
-  
-  belongs_to :building, optional: :true
+  validates :floor_number, presence: { message: "を選択してください" }
+  validates :floor_usege, presence: { message: "を選択してください" }
+  validates :floor_area, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :floor_capacity, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates_associated :building
+
+  belongs_to :building
 end

--- a/app/models/information_by_floor.rb
+++ b/app/models/information_by_floor.rb
@@ -1,11 +1,11 @@
 class InformationByFloor < ApplicationRecord
-  validates :floor_number, presence: true
-  validates :floor_usege, presence: true
-  validates :floor_area, presence: true
-  validates :floor_capacity, presence: true
-  validates :windowless_id, presence: true
+  validates :floor_number, presence: { message: "を選択してください" }
+  validates :floor_usege, presence: { message: "を選択してください" }
+  validates :floor_area, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :floor_capacity, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :windowless_id, presence: { message: "を選択してください" }
   validates_associated :building
 
   belongs_to :building
-  belongs_to :windowless
+  belongs_to :windowless, optional: :true
 end

--- a/app/views/buildings/new.html.erb
+++ b/app/views/buildings/new.html.erb
@@ -5,6 +5,9 @@
     <%= f.label :name, "名称", class:"col-sm-3 control-label" %>
     <div class="col-sm-8">
       <%= f.text_field :name, autofocus: true, autocomplete: "name", class: 'form-control', placeholder: "建物名称を入力してください" %>
+      <% if @building.errors.include?(:name) %>
+        <p class="error_message"><%= @building.errors.full_messages_for(:name).first %></p>
+      <% end %>
     </div>
   </div>
 
@@ -12,6 +15,9 @@
     <%= f.label :address, "住所", class:"col-sm-3 control-label" %>
     <div class="col-sm-8">
       <%= f.text_field :address, autofocus: true, autocomplete: "address", class: 'form-control', placeholder: "建物の住所を入力してください"%>
+      <% if @building.errors.include?(:address) %>
+        <p class="error_message"><%= @building.errors.full_messages_for(:address).first %></p>
+      <% end %>
     </div>
   </div>
 
@@ -19,20 +25,29 @@
     <%= f.label :entirety_usege_id, "全体用途", class:"col-sm-3 control-label"  %>
     <div class="col-sm-8">
       <%= f.collection_select :entirety_usege_id, @entirety_useges, :id, :view_category_and_example, {prompt: "選択してください"} %>
+      <% if @building.errors.include?(:entirety_usege_id) %>
+        <p class="error_message"><%= @building.errors.full_messages_for(:entirety_usege_id).first %></p>
+      <% end %>
     </div>
   </div>
 
   <div class="form-group">
     <%= f.label :total_area, "延べ床面積（㎡）", class:"col-sm-3 control-label" %>
     <div class="col-sm-8">
-      <%= f.text_field :total_area, autofocus: true, type: 'tel', class: 'form-control' %>
+      <%= f.text_field :total_area, autofocus: true, type: 'tel', placeholder: "半角数字で入力してください", class: 'form-control' %>
+      <% if @building.errors.include?(:total_area) %>
+        <p class="error_message"><%= @building.errors.full_messages_for(:total_area).first %></p>
+      <% end %>
     </div>
   </div>
 
   <div class="form-group">
     <%= f.label :total_capacity, "総収容人員（人）", class:"col-sm-3 control-label" %>
     <div class="col-sm-8">
-      <%= f.text_field :total_capacity, autofocus: true, class: 'form-control' %>
+      <%= f.text_field :total_capacity, autofocus: true, placeholder: "半角数字で入力してください", class: 'form-control' %>
+      <% if @building.errors.include?(:total_capacity) %>
+        <p class="error_message"><%= @building.errors.full_messages_for(:total_capacity).first %></p>
+      <% end %>
     </div>
   </div>
 
@@ -40,6 +55,9 @@
     <%= f.label :basement_floor, "地階", class: "col-sm-3 control-label" %>
     <div class="col-sm-8">
       <%= f.select :basement_floor, @entirety_basement_floors, {prompt: "選択してください"} %>
+      <% if @building.errors.include?(:basement_floor) %>
+        <p class="error_message"><%= @building.errors.full_messages_for(:basement_floor).first %></p>
+      <% end %>
     </div>
   </div>
 
@@ -58,6 +76,9 @@
     <%= f.label :entirety_floor, "階数", class:"col-sm-3 control-label" %>
     <div class="col-sm-8">
       <%= f.select :entirety_floor, @entirety_floors, {prompt: "選択してください"} %>
+      <% if @building.errors.include?(:entirety_floor) %>
+        <p class="error_message"><%= @building.errors.full_messages_for(:entirety_floor).first %></p>
+      <% end %>
     </div>
   </div>
   

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,9 @@ module FireFightingEquipment
     config.i18n.default_locale = :ja
     # タイムゾーン変更
     config.time_zone = 'Asia/Tokyo'
+    # エラーメッセージの日本語化
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
+    # エラーメッセージ表示時のレイアウト崩れ防止
+    config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,27 @@
+ja:
+  activerecord:
+    models:
+      building: "建物"
+      information_by_floor: "階別情報"
+    attributes:
+      building:
+        name: 建物名称
+        address: 住所
+        entirety_usege_id: 全体用途
+        entirety_floor: 階数
+        basement_floor: 地階
+        total_area: 延べ床面積
+        total_capacity: 総収容人員 
+        fire_use: 火気使用の有無
+      information_by_floors:
+        floor_number: 階数
+        floor_usege: 階別用途
+        floor_area: 階別床面積
+        floor_capacity: 階別収容人員
+        windowless_id: 無窓階判定
+        windowless: 無窓階判定
+      information_by_basement_floors:
+        floor_number: 階数
+        floor_usege: 階別用途
+        floor_area: 階別床面積
+        floor_capacity: 階別収容人員


### PR DESCRIPTION
＜変更内容＞
validation内容の変更
エラー表示場所の変更（各フォーム下に赤字で表示）
エラーメッセージの日本語化

＜未実装＞
ネストしたフォーム部分のエラー表示
`errors.full_messages_for(:name)`を使用して各フォーム下にエラーメッセージを表示していますが、ネストした部分はカラム名をうまく指定できず、表示できていません。
`errors.full_messages`をeach文でフォームの一番上に表示させる際は全て（ネストした部分）のエラーメッセージ が表示できているため、＠building内に全てのエラーメッセージ は保持できていると思います。カラムの指定方法を検索したのですが、うまくいくものがなかったため、一度プルリクエストさせていただきました。ご教授いただければと思います。

＜解決後に実装したいもの＞
「建物全体の情報として選択する階数」と「階別情報を入力する部分の最後に入力する階数」が一致しないと登録できないようにするvalidationを追加する。

以上です。よろしくお願いします。